### PR TITLE
show_in_rest for location taxonomy in gutenberg editor

### DIFF
--- a/src/src/classes/class-slw-product-taxonomy.php
+++ b/src/src/classes/class-slw-product-taxonomy.php
@@ -88,6 +88,7 @@ if(!class_exists('SlwProductTaxonomy')) {
                 'public'                     => true,
                 'show_ui'                    => true,
                 'show_admin_column'          => true,
+                'show_in_rest'               => true,
                 'show_in_nav_menus'          => true,
 				'show_tagcloud'              => true,
 				'capabilities'               => $capabilities,


### PR DESCRIPTION
Hi, I develop WooCommerce using this plugin.
But my product editor is using Gutenberg and location term is not appear there.
So my team fix some code here

Please check it and accept the pull request
Thanks! :)