### PR TITLE
Swapped to using woocommerce method for getting parent id, stops vari…

### DIFF
--- a/src/src/classes/class-slw-rest.php
+++ b/src/src/classes/class-slw-rest.php
@@ -96,7 +96,7 @@ if(!class_exists('SlwProductRest')) {
 
 			// Get parent post ID
 			// This is either the current product or its parent_id
-			$parentPostId = ($object_type === 'product_variation') ? $post->parent_id : $postId;
+			$parentPostId = ($object_type === 'product_variation') ? $post->get_parent_id() : $postId;
 
 			$stockLocationTermIds = array();
 


### PR DESCRIPTION
Stops a alert / warning message spamming the log files due to direct property access.