### PR TITLE
Order previous stock locations

### DIFF
--- a/src/src/classes/class-slw-location-taxonomy.php
+++ b/src/src/classes/class-slw-location-taxonomy.php
@@ -188,13 +188,13 @@ if(!class_exists('SlwLocationTaxonomy')) {
 				}
 			}
 
-            wp_cache_delete(self::$location_cache_key, \SlwMain::$plugin_basename);
+            wp_cache_delete(self::$location_cache_key, SLW_PLUGIN_BASENAME);
 		}
 
 		public static function getLocations()
         {
             // Get cached value
-            $locations = wp_cache_get(self::$location_cache_key, \SlwMain::$plugin_basename);
+            $locations = wp_cache_get(self::$location_cache_key, SLW_PLUGIN_BASENAME);
 
             // Cache is not valid, lets get a fresh copy
             if ($locations === false) {
@@ -203,7 +203,7 @@ if(!class_exists('SlwLocationTaxonomy')) {
                     'hide_empty' => false,
                 ) );
 
-                wp_cache_add(self::$location_cache_key, $locations, \SlwMain::$plugin_basename);
+                wp_cache_add(self::$location_cache_key, $locations, SLW_PLUGIN_BASENAME);
             }
 
             return $locations;

--- a/src/src/classes/class-slw-location-taxonomy.php
+++ b/src/src/classes/class-slw-location-taxonomy.php
@@ -17,6 +17,7 @@ if(!class_exists('SlwLocationTaxonomy')) {
 	{
 		public static $tax_plural_name = 'locations';
 		public static $tax_singular_name = 'location';
+		private static $location_cache_key = 'slw_locations';
 		private $plugin_settings;
 
 		/**
@@ -180,7 +181,27 @@ if(!class_exists('SlwLocationTaxonomy')) {
 					update_term_meta($term_id, 'slw_location_email', sanitize_text_field($_POST['location_email']));
 				}
 			}
+
+            wp_cache_delete(self::$location_cache_key, \SlwMain::$plugin_basename);
 		}
+
+		public static function getLocations()
+        {
+            // Get cached value
+            $locations = wp_cache_get(self::$location_cache_key, \SlwMain::$plugin_basename);
+
+            // Cache is not valid, lets get a fresh copy
+            if ($locations === false) {
+                $locations = get_terms( array(
+                    'taxonomy' => SlwLocationTaxonomy::$tax_singular_name,
+                    'hide_empty' => false,
+                ) );
+
+                wp_cache_add(self::$location_cache_key, $locations, \SlwMain::$plugin_basename);
+            }
+
+            return $locations;
+        }
 
 	}
 

--- a/src/src/classes/class-slw-order-item.php
+++ b/src/src/classes/class-slw-order-item.php
@@ -156,7 +156,7 @@ if( !class_exists('SlwOrderItem') ) {
 					$product_stock_location_terms = SlwStockAllocationHelper::getProductStockLocations($parent_id, true, null);
 
 					// If parent doesn't have terms show message
-					if(!$product_stock_location_terms) {
+					if(!$product_stock_location_terms && !SlwOrderItemHelper::productStockLocationsInputsAddPreviousStock([], $item)) {
 						echo '<td width="15%">';
 						echo '<div display="block">' . __('To be able to manage the stock for this product, please add it to a <b>Stock location</b>!', 'stock-locations-for-woocommerce') . '</div>';
 						echo '</td>';
@@ -174,7 +174,7 @@ if( !class_exists('SlwOrderItem') ) {
 					$product_stock_location_terms = SlwStockAllocationHelper::getProductStockLocations($product_id, true, null);
 
 					// If product doesn't have terms show message
-					if(!$product_stock_location_terms) {
+					if(!$product_stock_location_terms && !SlwOrderItemHelper::productStockLocationsInputsAddPreviousStock([], $item)) {
 						echo '<td width="15%">';
 						echo '<div display="block">' . __('To be able to manage the stock for this product, please add it to a <b>Stock location</b>!', 'stock-locations-for-woocommerce') . '</div>';
 						echo '</td>';

--- a/src/src/classes/class-slw-order-item.php
+++ b/src/src/classes/class-slw-order-item.php
@@ -210,7 +210,7 @@ if( !class_exists('SlwOrderItem') ) {
             // Add previous stock locations to view, this is so users can see how stock was previous allocated on past orders,
             // for example if 2 items where allocated to location 2, but location 2 is no longer a valid location for this stock item,
             // for this order the stock was stilled fulfilled by location 2 at the time of the order being processed.
-            $product_stock_location_terms = $this->productStockLocationsInputsAddPreviousStock($product_stock_location_terms, $item);
+            $product_stock_location_terms = SlwOrderItemHelper::productStockLocationsInputsAddPreviousStock($product_stock_location_terms, $item);
 
             // If product allows stock management
 			if( $product->get_manage_stock() == 'true' ) {
@@ -297,33 +297,6 @@ if( !class_exists('SlwOrderItem') ) {
 			}
 
 		}
-
-        private function productStockLocationsInputsAddPreviousStock($product_stock_location_terms, $item)
-        {
-            // Additional locations to add on the fly
-            $additionalLocations = array();
-
-            // Get all locations
-            $locations = SlwLocationTaxonomy::getLocations();
-
-            // Find other locations which have been allocated previously but that location is no longer part of this product
-            foreach ($locations as $location) {
-                // Make sure we dont include already existing stock locations (duplicates)
-                if (!isset($product_stock_location_terms[$location->term_id])) {
-                    // Check if there is meta against the item
-                    $hiddenLocationStock = $item->get_meta('_item_stock_updated_at_' . $location->term_id);
-
-                    // Make sure we found meta and it is not empty
-                    // This means this item has previously had stock allocated to a location, which is no longer part of this item,
-                    // but for historic reasons we want to see how the stock was allocated at the time of the order.
-                    if ($hiddenLocationStock !== false && !empty($hiddenLocationStock)) {
-                        $additionalLocations[$location->term_id] = $location;
-                    }
-                }
-            }
-
-            return array_merge($product_stock_location_terms, $additionalLocations);
-        }
 
 		/**
 		 * Reduces order items locations stock.

--- a/src/src/classes/class-slw-order-item.php
+++ b/src/src/classes/class-slw-order-item.php
@@ -193,7 +193,12 @@ if( !class_exists('SlwOrderItem') ) {
 			if( empty($product = wc_get_product($id)) ) return;
 			if( empty($item) ) return;
 
-			// If product allows stock management
+            // Add previous stock locations to view, this is so users can see how stock was previous allocated on past orders,
+            // for example if 2 items where allocated to location 2, but location 2 is no longer a valid location for this stock item,
+            // for this order the stock was stilled fulfilled by location 2 at the time of the order being processed.
+            $product_stock_location_terms = $this->productStockLocationsInputsAddPreviousStock($product_stock_location_terms, $item);
+
+            // If product allows stock management
 			if( $product->get_manage_stock() == 'true' ) {
 
 				// Add the input field to values table
@@ -278,6 +283,33 @@ if( !class_exists('SlwOrderItem') ) {
 			}
 
 		}
+
+        private function productStockLocationsInputsAddPreviousStock($product_stock_location_terms, $item)
+        {
+            // Additional locations to add on the fly
+            $additionalLocations = array();
+
+            // Get all locations
+            $locations = SlwLocationTaxonomy::getLocations();
+
+            // Find other locations which have been allocated previously but that location is no longer part of this product
+            foreach ($locations as $location) {
+                // Make sure we dont include already existing stock locations (duplicates)
+                if (!isset($product_stock_location_terms[$location->term_id])) {
+                    // Check if there is meta against the item
+                    $hiddenLocationStock = $item->get_meta('_item_stock_updated_at_' . $location->term_id);
+
+                    // Make sure we found meta and it is not empty
+                    // This means this item has previously had stock allocated to a location, which is no longer part of this item,
+                    // but for historic reasons we want to see how the stock was allocated at the time of the order.
+                    if ($hiddenLocationStock !== false && !empty($hiddenLocationStock)) {
+                        $additionalLocations[$location->term_id] = $location;
+                    }
+                }
+            }
+
+            return array_merge($product_stock_location_terms, $additionalLocations);
+        }
 
 		/**
 		 * Updates Stock Locations upon WC Order save.

--- a/src/src/helpers/helper-slw-order-item.php
+++ b/src/src/helpers/helper-slw-order-item.php
@@ -6,6 +6,8 @@
 
 namespace SLW\SRC\Helpers;
 
+use SLW\SRC\Classes\SlwLocationTaxonomy;
+
 if ( !defined('WPINC') ) {
 	die;
 }
@@ -142,6 +144,33 @@ if ( !class_exists('SlwOrderItemHelper') ) {
 
 			return true;
 		}
+
+        public static function productStockLocationsInputsAddPreviousStock($product_stock_location_terms, $item)
+        {
+            // Additional locations to add on the fly
+            $additionalLocations = array();
+
+            // Get all locations
+            $locations = SlwLocationTaxonomy::getLocations();
+
+            // Find other locations which have been allocated previously but that location is no longer part of this product
+            foreach ($locations as $location) {
+                // Make sure we dont include already existing stock locations (duplicates)
+                if (!isset($product_stock_location_terms[$location->term_id])) {
+                    // Check if there is meta against the item
+                    $hiddenLocationStock = $item->get_meta('_item_stock_updated_at_' . $location->term_id);
+
+                    // Make sure we found meta and it is not empty
+                    // This means this item has previously had stock allocated to a location, which is no longer part of this item,
+                    // but for historic reasons we want to see how the stock was allocated at the time of the order.
+                    if ($hiddenLocationStock !== false && !empty($hiddenLocationStock)) {
+                        $additionalLocations[$location->term_id] = $location;
+                    }
+                }
+            }
+
+            return array_merge($product_stock_location_terms, $additionalLocations);
+        }
 
 	}
 	


### PR DESCRIPTION
When an order is placed and stock has been allocated. If you come back to view an order and the previous stock location is no longer linked to the product, you cannot see how stock was allocated. This know does the stock showing on the order item line as normal, and then also checks if order line meta for any meta stock allocations which used to exist but no longer valid.

Real world example: customer placed order, 4 weeks alter they returned it and owner has gone to check which warehouse the items need to go back to, but the item was removed from warehouse 2, so it only told him there half the allocation was from.