### PR TITLE
Fixes issue with location priority sorting

### DIFF
--- a/src/src/helpers/helper-slw-stock-allocation.php
+++ b/src/src/helpers/helper-slw-stock-allocation.php
@@ -212,8 +212,8 @@ if( !class_exists('SlwStockAllocationHelper') ) {
 			// Sort
 			uasort($locations, function($a, $b)
 			{
-				$a_priority = isset($a->slw_location_priority) ?: $a->term_id;
-				$b_priority = isset($b->slw_location_priority) ?: $b->term_id;
+				$a_priority = $a->slw_location_priority ?? $a->term_id;
+				$b_priority = $b->slw_location_priority ?? $b->term_id;
 				
 				if ($a_priority == $b_priority) {
 					return 0;


### PR DESCRIPTION
Hi,

I think I've come across and issue regarding sorting the locations according to their priority.

In `SlwStockAllocationHelper::sortLocationsByPriority()` lines 215 and 216 ( [Direct Link](https://github.com/alexmigf/stock-locations-for-woocommerce/blob/c96ef50a2b905b658fd1789b332f03139533b53c/src/src/helpers/helper-slw-stock-allocation.php#L215) ) there is a check with a ternary operator on whether `slw_location_priority` exists for both locations.

The `?:` for both cases returns `true` if it exists (the result of `isset($a->slw_location_priority)` ) or the term id if it doesn't. The actual priority is never returned.

This causes the check in line 218 to be true (because `$a_priority = $b_priority = true`) and the entire `uasort` function returns `0`.

I think the fix is fairly straightforward (replacing the isset and ternary with a Null coalescing operator), please let me know what you think.